### PR TITLE
Fix createService not passing registry auth

### DIFF
--- a/src/docker-api.ts
+++ b/src/docker-api.ts
@@ -1,10 +1,9 @@
-import Dockerode, {ConfigInfo, NetworkInspectInfo, Service} from "dockerode";
+import Dockerode, {AuthConfigObject, ConfigInfo, NetworkInspectInfo, Service} from "dockerode";
 import {initServiceSpec, sortServiceSpec} from "./service-spec.js";
 import {HashedConfigs} from "./hashed-config.js";
 import {assertString} from "./asserts.js";
 import {SwarmAppConfig} from "./swarm-app-config.js";
 import {resolveAuthConfig} from "./docker-config.js";
-import {AuthConfigObject} from "dockerode";
 import timers from "timers/promises";
 import assert from "assert";
 
@@ -128,7 +127,11 @@ export async function upsertServices ({dockerode, config, current, appName, hash
         const foundService = current.services.find((s) => s.Spec?.Name === `${appName}_${serviceName}`);
         if (!foundService) {
             console.log(`Creating service ${appName}_${serviceName}`);
-            await dockerode.createService({...serviceSpec, authconfig});
+            if (authconfig) {
+                await dockerode.createService(authconfig, serviceSpec);
+            } else {
+                await dockerode.createService(serviceSpec);
+            }
         } else {
             serviceSpec.version = foundService.Version?.Index ?? 0;
             console.log(`Updating service ${appName}_${serviceName}`);

--- a/src/docker-config.ts
+++ b/src/docker-config.ts
@@ -23,5 +23,11 @@ export function resolveAuthConfig (image: string, auths: Record<string, AuthConf
     const entry = auths[registry];
     if (!entry?.auth) return undefined;
 
-    return {auth: entry.auth, serveraddress: registry};
+    const decoded = Buffer.from(entry.auth, "base64").toString();
+    const separatorIndex = decoded.indexOf(":");
+    if (separatorIndex === -1) return undefined;
+    const username = decoded.substring(0, separatorIndex);
+    const password = decoded.substring(separatorIndex + 1);
+
+    return {username, password, serveraddress: registry};
 }


### PR DESCRIPTION
## Summary
- Docker Swarm's task agent doesn't understand the raw base64 `auth` field from `~/.docker/config.json` — it needs explicit `username`/`password` fields in the `X-Registry-Auth` header
- Decode the `auth` field (base64-encoded `username:password`) into separate `username` and `password` fields before sending
- Also fix `createService` to pass auth as a separate first argument, since dockerode's single-arg codepath for `createService` doesn't extract `authconfig` from the options (unlike `service.update`)

## Test plan
- [x] Verified `docker service create --with-registry-auth` (Docker CLI) also fails with same error — confirming the raw auth field format is the issue
- [x] Verified explicit `username`/`password` auth via Docker API succeeds
- [x] Built and deployed with swarm-app locally — service pulls from `registry.cego.dk` successfully