### PR TITLE
Fix command/entrypoint mapping to match Docker semantics

### DIFF
--- a/examples/swarm-app.yml
+++ b/examples/swarm-app.yml
@@ -21,6 +21,7 @@ service_specs:
   # {% endif %}
 
   nginx:
+    entrypoint: ["/docker-entrypoint.sh"]
     command: ["nginx", "-g", "daemon off;"]
     image: {{ env.NGINX_IMAGE_REF }}
     container_labels:

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -72,7 +72,8 @@ export function initServiceSpec ({appName, serviceName, config, hashedConfigs, c
             ContainerSpec: {
                 Image: serviceConfig.image,
                 Labels: serviceConfig.container_labels,
-                Command: serviceConfig.command,
+                Command: serviceConfig.entrypoint,
+                Args: serviceConfig.command,
                 Env: env,
                 StopSignal: serviceConfig.stop_signal,
                 StopGracePeriod: serviceConfig.stop_grace_period,

--- a/tests/service-spec.test.ts
+++ b/tests/service-spec.test.ts
@@ -1,0 +1,60 @@
+import {test, expect} from "@jest/globals";
+import {initServiceSpec} from "../src/service-spec.js";
+import {HashedConfigs} from "../src/hashed-config.js";
+import {SwarmAppConfig} from "../src/swarm-app-config.js";
+import {assertTaskTemplateContainerTaskSpec} from "../src/asserts.js";
+
+test("command maps to Args and entrypoint maps to Command", () => {
+    const config: SwarmAppConfig = {
+        networks: {
+            default: {name: "test-network", external: true},
+        },
+        service_specs: {
+            server: {
+                image: "cloudflare/cloudflared:2026.3.0",
+                entrypoint: ["cloudflared", "--no-autoupdate"],
+                command: ["tunnel", "run", "some-uuid"],
+                service_labels: {"com.docker.stack.namespace": "test"},
+                container_labels: {"com.docker.stack.namespace": "test"},
+            },
+        },
+    };
+
+    const spec = initServiceSpec({
+        appName: "test",
+        serviceName: "server",
+        config,
+        hashedConfigs: new HashedConfigs(),
+    });
+
+    assertTaskTemplateContainerTaskSpec(spec);
+    expect(spec.TaskTemplate.ContainerSpec.Command).toEqual(["cloudflared", "--no-autoupdate"]);
+    expect(spec.TaskTemplate.ContainerSpec.Args).toEqual(["tunnel", "run", "some-uuid"]);
+});
+
+test("command without entrypoint sets Args only", () => {
+    const config: SwarmAppConfig = {
+        networks: {
+            default: {name: "test-network", external: true},
+        },
+        service_specs: {
+            server: {
+                image: "nginx:latest",
+                command: ["nginx", "-g", "daemon off;"],
+                service_labels: {"com.docker.stack.namespace": "test"},
+                container_labels: {"com.docker.stack.namespace": "test"},
+            },
+        },
+    };
+
+    const spec = initServiceSpec({
+        appName: "test",
+        serviceName: "server",
+        config,
+        hashedConfigs: new HashedConfigs(),
+    });
+
+    assertTaskTemplateContainerTaskSpec(spec);
+    expect(spec.TaskTemplate.ContainerSpec.Command).toBeUndefined();
+    expect(spec.TaskTemplate.ContainerSpec.Args).toEqual(["nginx", "-g", "daemon off;"]);
+});


### PR DESCRIPTION
## Summary
- `command` was mapped to `ContainerSpec.Command` (ENTRYPOINT override) instead of `ContainerSpec.Args` (CMD)
- `entrypoint` field existed in the schema but was never wired up
- This broke images with entrypoints (e.g. `cloudflare/cloudflared`) where `command: ["tunnel", "run", ...]` tried to execute `tunnel` as a binary

## Changes
- Map `command` to `ContainerSpec.Args` and `entrypoint` to `ContainerSpec.Command`
- Add `entrypoint` to the example swarm-app.yml
- Add tests for command/entrypoint mapping

## Test plan
- [x] Existing tests pass
- [x] New tests verify command maps to Args and entrypoint maps to Command
- [x] ESLint passes