### PR TITLE
Fix YAML schema inconsistencies

### DIFF
--- a/examples/swarm-app.yml
+++ b/examples/swarm-app.yml
@@ -46,7 +46,7 @@ service_specs:
       - shared
     replicas: 2
     stop_signal: SIGQUIT
-    stop_grace_period: 10
+    stop_grace_period: 10000000000 # 10s (nanoseconds)
     user: '0'
     dir: /etc/nginx
     placement:
@@ -72,4 +72,4 @@ service_specs:
       /etc/nginx/:
         source: "web-data"
         type: "volume" # "bind|volume"
-        readonly: true
+        read_only: true

--- a/schema.json
+++ b/schema.json
@@ -171,7 +171,7 @@
                     "bind"
                   ]
                 },
-                "readonly": {
+                "read_only": {
                   "type": "boolean"
                 }
               }

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -47,7 +47,7 @@ export function initServiceSpec ({appName, serviceName, config, hashedConfigs, c
     if (byServiceName.length > 0) {
         configs = byServiceName.map(({targetPath, hash}) => {
             return {
-                File: {Name: targetPath, UID: "0", GID: "0", Mode: 0},
+                File: {Name: targetPath, UID: "0", GID: "0", Mode: 0o444},
                 ConfigID: current?.configs.find((c) => c.Spec?.Name === hash)?.ID,
                 ConfigName: hash,
             };
@@ -94,7 +94,7 @@ export function initServiceSpec ({appName, serviceName, config, hashedConfigs, c
                         Target: t,
                         Source: m.source,
                         Type: m.type,
-                        ReadOnly: m.readonly,
+                        ReadOnly: m.read_only,
                     };
                 }),
             },

--- a/src/swarm-app-config.ts
+++ b/src/swarm-app-config.ts
@@ -57,7 +57,7 @@ export interface SwarmAppServiceConfig {
     mounts?: Record<string, {
         source: string;
         type: "bind" | "volume";
-        readonly: boolean;
+        read_only: boolean;
     }>;
     update_config?: {
         parallelism: number;
@@ -151,7 +151,7 @@ export const swarmAppConfigSchema: JTDSchemaType<SwarmAppConfig> = {
                             properties: {
                                 source: {type: "string"},
                                 type: {enum: ["volume", "bind"]},
-                                readonly: {type: "boolean"},
+                                read_only: {type: "boolean"},
                             },
                         },
                     },


### PR DESCRIPTION
## Summary
Three schema-vs-mapping inconsistencies surfaced while reviewing #127.

- `examples/swarm-app.yml`: `stop_grace_period: 10` was 10ns. Bumped to `10000000000 # 10s (nanoseconds)` to match the convention #109 established for `health_check` durations.
- `mounts.readonly` → `mounts.read_only` — every other multi-word field in the schema is snake_case (`stop_signal`, `target_port`, `start_interval`, …); `readonly` was the only outlier. Docker Compose itself uses `read_only`. **Breaking** for any consumer still on `readonly:`.
- `ConfigReference.File.Mode` was hardcoded to `0` (= `chmod 000`). Set to `0o444` to match Docker Compose's documented default. Existing deployments will show a one-time diff until redeployed.

## Test plan
- [x] `tsc` clean
- [x] `eslint .` clean
- [x] `jest` passes