### PR TITLE
Settle wait only after sustained, restart-free checks

### DIFF
--- a/src/commands/wait-cmd.ts
+++ b/src/commands/wait-cmd.ts
@@ -26,12 +26,18 @@ export async function handler (args: ArgumentsCamelCase) {
     assertNumber(timeout, "timeout must be a number in ms");
     const interval = args.interval;
     assertNumber(interval, "interval must be a number in ms");
+    const stableChecks = args.stableChecks;
+    assertNumber(stableChecks, "stableChecks must be a number");
 
     const dockerode = new Docker();
 
     console.log(`Awaiting task reconciliation for ${timeout}ms`);
 
     let services: Service[], tasks: Task[], timedout, bail, serviceStateMap;
+    let stableStreak = 0;
+    const seenFailedTaskIds = new Set<string>();
+    const restartCooldown = new Map<string, number>();
+    let firstCheck = true;
     const start = Date.now();
     do {
         // To prevent high cpu usage
@@ -55,10 +61,31 @@ export async function handler (args: ArgumentsCamelCase) {
             }
         }
 
+        for (const t of tasks) {
+            if (!["failed", "rejected"].includes(t.Status.State) || seenFailedTaskIds.has(t.ID)) {
+                continue;
+            }
+            seenFailedTaskIds.add(t.ID);
+            if (!firstCheck) {
+                restartCooldown.set(t.ServiceID, stableChecks);
+            }
+        }
+        firstCheck = false;
+
+        for (const [serviceId, remaining] of restartCooldown) {
+            serviceStateMap.set(serviceId, "restarting");
+            restartCooldown.set(serviceId, remaining - 1);
+            if (remaining - 1 <= 0) {
+                restartCooldown.delete(serviceId);
+            }
+        }
+
         const servicesUpdating = [...serviceStateMap.entries()];
 
-        bail = servicesUpdating.length === 0;
-        if (!bail) {
+        if (servicesUpdating.length === 0) {
+            stableStreak++;
+        } else {
+            stableStreak = 0;
             for (const [serviceId, state] of servicesUpdating) {
                 const serviceName = services.find((s) => s.ID === serviceId)?.Spec?.Name;
                 assert(serviceName != null, "serviceName must be a string");
@@ -66,6 +93,8 @@ export async function handler (args: ArgumentsCamelCase) {
                 console.log(`${serviceName} is in ${state} state${errMsg ? ", error: '" + errMsg + "'" : ""}`);
             }
         }
+
+        bail = stableStreak >= stableChecks;
     } while (!timedout && !bail);
 
     if (timedout) {
@@ -87,6 +116,11 @@ export function builder (yargs: Argv) {
         type: "number",
         description: "How often reconciliation should run",
         default: 5000,
+    });
+    yargs.positional("stableChecks", {
+        type: "number",
+        description: "Consecutive settled checks required before success",
+        default: 3,
     });
     yargs.hide("help");
     yargs.hide("version");


### PR DESCRIPTION
The `wait` command declared success on the first poll where every service had its desired replicas running and no active `UpdateStatus`. Swarm marks a task `running` the moment it starts, so a crash-looping container is `running` between restarts; a single lucky poll yielded a false green (wheatley-server 2.4.0 crash-looping in prod while the deploy job went green on retry).

A service is now settled only when, for `stableChecks` (default 3) consecutive checks: replicas are fully running, no active update, and no newly failed task has appeared. A new task failure puts the service on a `restarting` cooldown for a full `stableChecks` window, so a container that crash-loops faster than that window can never reach success.

Verified on a local single-node swarm (alpine `sleep 2; exit 1`, restart loop ~6s period):
- crash-loop at default interval 5s → correctly times out (3/3 fresh deploys)
- old code on the same service → false `Reconciliation succeeded`
- healthy service → succeeds
- crash-loop updated to a healthy command → succeeds despite prior failure history

Limitation: detection needs the observation window `(stableChecks-1) × interval` (10s at defaults) to exceed the crash-restart period. wheatley restarts ~7s, so defaults catch it; a slower crash-loop (period >10s) would need a higher `stableChecks` or `interval`. Jest is unrelated/pre-broken on `main` (ESM config); tsc and eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)